### PR TITLE
Baseline Tools and Tests groups require Core

### DIFF
--- a/src/BaselineOfXMLWriter/BaselineOfXMLWriter.class.st
+++ b/src/BaselineOfXMLWriter/BaselineOfXMLWriter.class.st
@@ -27,10 +27,10 @@ BaselineOfXMLWriter >> baseline: spec [
 			"Groups"
 			spec
 				group: 'Core' with: #('XML-Writer-Core');
-				group: 'Tools' with: #('OrderPreservingDictionary Tools');  
-				group: 'Tests' with: #('XML-Writer-Tests');
+				group: 'Tools' with: #('OrderPreservingDictionary Tools' 'Core');  
+				group: 'Tests' with: #('Core' 'XML-Writer-Tests');
 				group: 'CI' with: #('Tests');	
-				group: 'all' with: #('Core' 'Tools' 'Tests');
+				group: 'all' with: #('Tools' 'Tests');
 				group: 'default' with: #('all') ].
 
 	"load gemstone compatibility methods"


### PR DESCRIPTION
Tools ~~and Tests~~ groups could have not been loaded without adding 'Core', fixed now by making 'Core' their dependency.